### PR TITLE
Add new style hyperpolling dongle support

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,10 @@ const dongles = {
         model: models_.HyperPollingDongle,
         is_8k_compatible: true,
     },
+    0x00C3: {
+        model: models_.HyperPollingDongle,
+        is_8k_compatible: true,
+    },
     0x00A4: {
         model: models_.DockPro,
         is_8k_compatible: true,


### PR DESCRIPTION
The new Razer DAv3 pros have a rubber texture and come bundled with the hyperpolling wireless dongle (plus new packaging, no grips, etc. A friend purchased a new one today). 

The application cannot find this new hyperpolling dongle. USB Tree View shows the identifier has seemingly changed to C3. The device description has also changed and does not mention hyperpolling like the old dongles do. Same for the device manager, no hyperpolling nomenclature anywhere. I tested adding C3 to my fork of your application and the dongle was found.